### PR TITLE
Reduce setup process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 package-lock.json
 .DS_Store
+db.sqlite3

--- a/README.md
+++ b/README.md
@@ -41,9 +41,26 @@ $ npm start // this will compile the react code using webpack and run them at po
 
 ## Server Side (PORT: 4000)
 
-## Prepare your secret
+## Environment  Variables (.env)
 
-You need to add a JWT_SECRET in .env
+    JWT_SECRET = YOUR_JWT_SECRET
+
+  ### NOTE: nodecloud currently supports MICROSOFT AZURE
+  Add the following Azure Credentials to your .env file 
+
+    AZURE_CLIENT_ID= YOUR_CLIENT_ID
+
+    AZURE_CLIENT_SECRET=YOUR_CLIENT_SECRET
+
+    AZURE_TENANT_ID=YOUR_TENANT_ID
+
+    AZURE_SUBSCRIPTION_ID=YOUR_SUBSCRIPTION_ID
+
+    AZURE_STORAGE_ACCESS_KEY=YOUR_STORAGE_ACCESS_KEY
+
+    AZURE_STORAGE_ACCOUNT=YOUR_STORAGE_ACCOUNT
+
+    AZURE_STORAGE_CONNECTION_STRING=YOUR_STORAGE_CONNECTION_STRING
 
 ## Start
 
@@ -77,5 +94,4 @@ $ docker-compose up
 </p>
 
 ## License
-
 MIT

--- a/server/db.js
+++ b/server/db.js
@@ -2,24 +2,30 @@
 const sqlite3 = require("sqlite3").verbose();
 
 // create a db instance
-const db = new sqlite3.Database("./user.sqlite3", err => {
+const db = new sqlite3.Database("./db.sqlite3", err => {
+  
   if (err) {
     console.log("Error when creating the database", err);
   } else {
-    console.log("Database created!");
     createTableUser();
     createTableService();
+    console.log("Database created!");
   }
 });
 
+const options = {
+  client: "sqlite3",
+  connection: {
+    filename: "./db.sqlite3"
+  },
+  useNullAsDefault: true
+};
+
 const createTableUser = () => {
-  const options = {
-    client: "sqlite3",
-    connection: {
-      filename: "./user.sqlite3"
-    }
-  };
+  
   const knex = require("knex")(options);
+  if(knex.schema.hasTable("users")) return;
+
   knex.schema
     .createTable("users", function(t) {
       t.increments("id").primary();
@@ -28,17 +34,14 @@ const createTableUser = () => {
       t.string("password").notNullable();
     })
     .then(console.log("User Table created"));
-  //     // db.run("CREATE TABLE IF NOT EXISTS users(id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, username TEXT, password TEXT)");
+    // db.run("CREATE TABLE IF NOT EXISTS users(id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, username TEXT, password TEXT)");
 };
 
 const createTableService = () => {
-  const options = {
-    client: "sqlite3",
-    connection: {
-      filename: "./user.sqlite3"
-    }
-  };
+  
   const knex = require("knex")(options);
+  if(knex.schema.hasTable("services")) return;
+
   knex.schema
     .createTable("services", function(t) {
       t.increments("id").primary();
@@ -47,7 +50,8 @@ const createTableService = () => {
       t.string("type").notNullable();
       t.string("location").notNullable();
     })
-    .then(console.log("Service Table created"));
+    .then(console.log("Service Table created"))
+    
 
   knex.schema
     .alterTable("services", function(t) {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "async": "^3.1.0",
+    "azure-arm-apimanagement": "^5.1.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.4",

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,7 @@ app.set("port", process.env.PORT || 4000);
 app.use(express.static("public"));
 app.use(cors());
 
-// const db = require("../server/db");
+const db = require("../server/db");
 
 const authRoutes = require("./routes/auth");
 app.use("/", authRoutes);


### PR DESCRIPTION
Nodecloud server setup process is too much and throws error most times due to some issues so i came up with a fix. below is the set up process for nodecloud and the fix i made.

## SETUP PROCESS & ISSUE
1. clone nodecloud-web
cd nodecloud-web/server and install dependencies
download nodecloud-azure-plugin from https://github.com/cloudlibz/nodecloud-azure-plugin and paste it inside nodeloud-web/server node_modules
i. cd nodecloud-azure-plugin
 i. npm i
 ii. npm link

2.  npm install azure-arm-apimanagement
3. Add Environment Variables

- JWT_SECRET=
- AZURE_CLIENT_ID=
- AZURE_CLIENT_SECRET=
- AZURE_TENANT_ID=
- AZURE_SUBSCRIPTION_ID=
- AZURE_STORAGE_ACCESS_KEY=
- AZURE_STORAGE_ACCOUNT=
- AZURE_STORAGE_CONNECTION_STRING=

4. nodecloud provider.js => `Throws Error`
5. SQLite Error => `Throws Error`;

## NEW SETUP PROCESS
1. clone nodecloud-web
cd nodecloud-web/server and install dependencies
download nodecloud-azure-plugin from https://github.com/cloudlibz/nodecloud-azure-plugin and paste it inside nodeloud-web/server node_modules
i. cd nodecloud-azure-plugin
 i. npm i
 ii. npm link

2. add Environment variables
3. npm start 

## CURRENT ISSUE
the nodecloud base-provider.js still throws error though but there is a fix for this already and here is the link to the issue I created https://github.com/cloudlibz/nodecloud/issues/32

