### PR TITLE
docker-compose repair

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,21 @@ services:
     restart: always
   backend:
     container_name: backend
-    build: ./node-backend/
+    build: ./server/
     restart: always
     ports:
       - "6200:6200"
     volumes:
-      - ./node-backend:/usr/src/app
+      - ./server:/usr/src/app
     depends_on:
       - sqlite
   frontend:
     container_name: frontend
-    build: ./react-frontend/
+    build: ./client/
     restart: always
     ports:
       - "3000:3000"
     volumes:
-      - ./react-frontend:/usr/src/app
+      - ./client:/usr/src/app
     depends_on:
       - backend


### PR DESCRIPTION
Fixes #28 
-

Apparently either the directories' name was recently updated or the `docker-compose.yml` file was updated. Because of this, the directories' names were not in sync and caused the error.

I have updated the file with `node-backend` as `server` and `react-frontend` as the `client` directory in the `docker-compose.yml` file.